### PR TITLE
Update 184.largestNumber.cpp

### DIFF
--- a/src/lintcode/184.largestNumber.cpp
+++ b/src/lintcode/184.largestNumber.cpp
@@ -23,7 +23,7 @@ public:
         string res;
         for (auto n : nums)
             res += to_string(n);
-        return res.empty() && res[0] == '0' ? "0" : res;
+        return res.empty() || res[0] == '0' ? "0" : res;
     }
 };
 


### PR DESCRIPTION
problem with the original code not being able to return 0 on some testcases due to "res.empty()&&res[0]='0'"